### PR TITLE
Add dependencies for OrbotIPtProxy go components

### DIFF
--- a/build-orbot.sh
+++ b/build-orbot.sh
@@ -8,14 +8,17 @@ export MIN_ANDROID_SDK=23
 
 if [ -d IPtProxy ]; then
   cd IPtProxy
-  git clean -f
+  git clean -fdx
+  git reset --hard
   if [ -d lyrebird ]; then
     cd lyrebird
+    git clean -fdx
     git reset --hard
     cd ..
   fi
   if [ -d snowflake ]; then
     cd snowflake
+    git clean -fdx
     git reset --hard
     cd ..
   fi
@@ -47,7 +50,10 @@ fi
 
 TEMPDIR="$TMPDIR/IPtProxy"
 printf '\n\n--- Prepare build environment at %s...\n' "$TEMPDIR"
-cd IPtProxy
+cd IPtProxy/IPtProxy.go
+go mod tidy
+go get golang.org/x/mobile/bind
+cd ..
 CURRENT=$PWD
 rm -rf "$TEMPDIR"
 mkdir -p "$TEMPDIR"


### PR DESCRIPTION
When OrbotIPtProxy's build script copies dns.go and OrbotTun.go to IPtProxy sources, there are additional go dependencies found by go mod tidy, ie; github.com/eycorsican/go-tun2socks

Therefore, execute 'go mod tidy' after copying additional go files to IPtProxy to incorporated additional go dependencies. Also, 'go mod tidy' will remove 'golang.org/x/mobile/bind' so add that back before resuming the build.